### PR TITLE
ARXIVNG-1672 tweaks to breadcrumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ longer because it has to download things.
 | SOURCE_PATH | Yes | No | Path to the markdown source directory for the site. |
 | BUILD_PATH | Yes | Yes | Path where the built site is/should be stored. |
 | SITE_HUMAN_NAME | No | Yes | Human-readable name of the site. |
+| SITE_HUMAN_SHORT_NAME | No | Yes | Human-readable short name; e.g. for breadcrumbs. |
 | SITE_URL_PREFIX | No | Yes | Path where the site should be served. Must start with ``/`` (default: ``/``). |
 | SITE_SEARCH_ENABLED | Yes | Yes | If set to 0, the search feature is excluded (default: 1). |
 

--- a/marxdown/config.py
+++ b/marxdown/config.py
@@ -18,6 +18,7 @@ TEMPLATE_ROOT = os.environ.get('TEMPLATE_ROOT', 'templates')
 EXTERNAL_URL_SCHEME = os.environ.get('EXTERNAL_URL_SCHEME', 'https')
 BASE_SERVER = os.environ.get('BASE_SERVER', 'arxiv.org')
 URLS = [
+    ("home", "/", BASE_SERVER),
     ("archive", "/archive/<archive>", BASE_SERVER),
     ("search_box", "/search", BASE_SERVER),
     ("clickthrough", "/ct", BASE_SERVER),
@@ -46,6 +47,7 @@ SOURCE_PATH = os.environ.get('SOURCE_PATH')
 BUILD_PATH = os.environ.get('BUILD_PATH')
 SITE_NAME = os.environ.get('SITE_NAME', 'arxiv')
 SITE_URL_PREFIX = os.environ.get('SITE_URL_PREFIX', '/')
+SITE_HUMAN_SHORT_NAME = os.environ.get('SITE_HUMAN_SHORT_NAME', 'Static')
 SITE_HUMAN_NAME = os.environ.get('SITE_HUMAN_NAME', 'arXiv Static Pages')
 SITE_SEARCH_ENABLED = bool(int(os.environ.get('SITE_SEARCH_ENABLED', 1)))
 APP_VERSION = "0.1"

--- a/marxdown/routes.py
+++ b/marxdown/routes.py
@@ -100,6 +100,9 @@ def get_blueprint(site_path: str, with_search: bool = True) -> Blueprint:
     blueprint.context_processor(
         lambda: {'site_human_name': site.get_site_human_name()}
     )
+    blueprint.context_processor(
+        lambda: {'site_human_short_name': site.get_site_human_short_name()}
+    )
     return blueprint
 
 

--- a/marxdown/services/site.py
+++ b/marxdown/services/site.py
@@ -142,8 +142,13 @@ def get_url_prefix() -> str:
 
 
 def get_site_human_name() -> str:
-    """Get the URL prefix for this site."""
+    """Get the human name for this site."""
     return config().get('SITE_HUMAN_NAME', 'arXiv static pages')
+
+
+def get_site_human_short_name() -> str:
+    """Get the human short name for this site."""
+    return config().get('SITE_HUMAN_SHORT_NAME', 'Static')
 
 
 def get_data_path() -> str:

--- a/marxdown/templates/docs/page.html
+++ b/marxdown/templates/docs/page.html
@@ -5,8 +5,13 @@
 <nav class="breadcrumb" aria-label="breadcrumbs">
   <ul>
     <li>
+      <a href="{{ url_for('home') }}">
+        arXiv
+      </a>
+    </li>
+    <li>
       <a href="{{ url_for(site_name + '.from_sitemap') }}">
-        {{ site_human_name }}
+        {{ site_human_short_name }}
       </a>
     </li>
     {% for parent in parents %}


### PR DESCRIPTION
Introduces config param ``SITE_HUMAN_SHORT_NAME`` (defaults to ``Site``). This is used for the second breadcrumb item. E.g. with ``SITE_HUMAN_SHORT_NAME=Help``:

![image](https://user-images.githubusercontent.com/3451594/52486562-7aaa3600-2b89-11e9-92d4-f96e708039c4.png)
