### PR TITLE
ARXIVNG-1696 gracefully handle uncommitted files in site source

### DIFF
--- a/marxdown/templates/docs/page.html
+++ b/marxdown/templates/docs/page.html
@@ -37,6 +37,6 @@
   {% block markdown_content %}
   {% endblock %}
   <aside class="has-text-centered" style="padding-top: 3rem;">
-    <p class="is-size-7">Version <a href="{{ version_url }}">{{ version }}</a>. Last modified <a href="{{ source_url }}">{{ modified|format_datetime }}</a>.</p>
+    <p class="is-size-7">Version <a href="{{ version_url }}">{{ version }}</a>. Last modified {% if source_url %}<a href="{{ source_url }}">{% endif %}{{ modified|format_datetime }}{% if source_url %}</a>{% endif %}.</p>
   </aside>
 {% endblock page_content %}


### PR DESCRIPTION
Fixes a bug where building from source with uncommitted files caused an error: 

```
Traceback (most recent call last):
  File "build.py", line 11, in <module>
    build_site(app.config.get('SITE_SEARCH_ENABLED', True))
  File "/opt_arxiv/e-prints/arxiv-help/marxdown/build.py", line 34, in build_site
    for source_page in source.load_pages():
  File "/opt_arxiv/e-prints/arxiv-help/marxdown/services/source.py", line 156, in load_pages
    yield load_page(source_path, page_path)
  File "/opt_arxiv/e-prints/arxiv-help/marxdown/services/source.py", line 133, in load_page
    metadata['modified'] = _get_mtime(source_path, page_path)
  File "/opt_arxiv/e-prints/arxiv-help/marxdown/services/source.py", line 58, in _get_mtime
    commit = _get_last_commit(source_path, page_path)
  File "/opt_arxiv/e-prints/arxiv-help/marxdown/services/source.py", line 53, in _get_last_commit
    commit: git.Commit = list(repo.iter_commits(paths=fpath, max_count=1))[0]
IndexError: list index out of range
```

This was because we were using the last commit associated with each file to generate the "last modified" time. This change falls back to the filesystem modified time if there is no commit for a file.