### PR TITLE
ARXIVNG-1704 added support for revision history

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,19 @@ response:
 ---
 ```
 
+## Revision history
+
+You can insert the revision history for a page using the ``render_history()``
+macro. This is the commit history, with links to the corresponding source
+on GitHub.
+
+```
+### Revision history
+
+- 2018-02-26 - Current version 1 created.
+$jinja {{ render_history(history) }} jinja$
+```
+
 ## Sitemap application
 
 ### Build

--- a/marxdown/factory.py
+++ b/marxdown/factory.py
@@ -15,9 +15,16 @@ s3 = FlaskS3()
 
 
 def format_datetime(datestring: str) -> str:
+    """Render a date like ``Friday, January 01, 2019 at 22:05 US/Eastern``."""
     dt = dateutil.parser.parse(datestring)
     dt = dt.replace(tzinfo=timezone('US/Eastern'))
-    return dt.strftime("%A, %B %m, %Y at %I:%M%p Eastern")
+    return dt.strftime("%A, %B %m, %Y at %H:%M US/Eastern")
+
+
+def simepledate(datestring: str) -> str:
+    """Render a date like ``1992-05-02``."""
+    dt = dateutil.parser.parse(datestring)
+    return dt.strftime("%Y-%m-%d")
 
 
 def create_web_app() -> Flask:
@@ -37,5 +44,6 @@ def create_web_app() -> Flask:
         )
     )
     app.jinja_env.filters['format_datetime'] = format_datetime
+    app.jinja_env.filters['simepledate'] = simepledate
     s3.init_app(app)
     return app

--- a/marxdown/templates/docs/history.html
+++ b/marxdown/templates/docs/history.html
@@ -1,0 +1,5 @@
+{% macro render_history(history) %}
+{% for github_url, created, message in history %}
+  <li><a href="{{ github_url }}" rel="external">{{ created|simepledate  }} - {{ message.capitalize() }}</a></li>
+{% endfor %}
+{% endmacro %}

--- a/marxdown/templates/docs/page.html
+++ b/marxdown/templates/docs/page.html
@@ -1,5 +1,7 @@
 {%- extends "docs/base.html" %}
 
+{% from "docs/history.html" import render_history %}
+
 {% block breadcrumbs %}
 {{ page.page_for_reference }}
 <nav class="breadcrumb" aria-label="breadcrumbs">
@@ -37,6 +39,6 @@
   {% block markdown_content %}
   {% endblock %}
   <aside class="has-text-centered" style="padding-top: 3rem;">
-    <p class="is-size-7">Version <a href="{{ version_url }}">{{ version }}</a>. Last modified {% if source_url %}<a href="{{ source_url }}">{% endif %}{{ modified|format_datetime }}{% if source_url %}</a>{% endif %}.</p>
+    <p class="is-size-7">"{{ title }}" revision <a href="{{ version_url }}">{{ version }}</a>. Last modified {% if source_url %}<a href="{{ source_url }}">{% endif %}{{ modified|format_datetime }}{% if source_url %}</a>{% endif %}.</p>
   </aside>
 {% endblock page_content %}


### PR DESCRIPTION
Also updated the revision footer at the bottom:
- "version" -> "revision"
- includes title of page 
- 12h -> 24h time
- "Eastern" -> "US/Eastern"

Looks like:
![image](https://user-images.githubusercontent.com/3451594/52490546-fb216480-2b92-11e9-9d2f-779d3090eda7.png)
