### PR TITLE
ARXIVNG-1726 don't mess with mailto: links

### DIFF
--- a/arxiv/marxdown/render.py
+++ b/arxiv/marxdown/render.py
@@ -151,8 +151,13 @@ class StyleClassExtension(Extension):
 
 def get_linker(page: SourcePage, site_name: str) -> Callable:
     def linker(href: str) -> Tuple[str, str, str, Optional[str]]:
-        if not href or '://' in href or href.startswith('/') \
-                or href.startswith('#'):
+        # We don't want to mess with things that are clearly not ours to
+        # fiddle with.
+        if not href \
+                or '://' in href \
+                or href.startswith('/') \
+                or href.startswith('#') \
+                or href.startswith('mailto:'):
             return href, None, None, None
         anchor = None
         if '#' in href:

--- a/arxiv/marxdown/tests/test_render.py
+++ b/arxiv/marxdown/tests/test_render.py
@@ -3,6 +3,16 @@ import re
 from .. import render
 
 
+class TestMailToLinks(TestCase):
+    """Link processing should not break ``mailto:`` links."""
+
+    def test_mailto_is_untouched(self):
+        """If a link starts with ``mailto:``, it shouldn't be fiddled with."""
+        raw = """click [here](mailto:help@arxiv.org)."""
+        expected = """<p>click <a href="mailto:help@arxiv.org">here</a>.</p>"""
+        self.assertEqual(render.render(raw), expected)
+
+
 class TestEscapeBrackets(TestCase):
     """Braces are common in TeX; we should not confuse them with Jinja."""
 


### PR DESCRIPTION
This fixes a bug where ``mailto:`` links were getting treated like links to static files (yuck).