### PR TITLE
ARXIVNG-1698 support for paths that end in .html

### DIFF
--- a/arxiv/marxdown/routes.py
+++ b/arxiv/marxdown/routes.py
@@ -108,6 +108,7 @@ def get_blueprint(site_path: str, with_search: bool = True) -> Blueprint:
                           static_url_path=f'{site.get_site_name()}_static')
     blueprint.route('/')(from_sitemap)
     blueprint.route('/<path:page_path>.html', endpoint="html")(from_sitemap)
+    blueprint.route('/<path:page_path>.htm', endpoint="htm")(from_sitemap)
     blueprint.route('/<path:page_path>')(from_sitemap)
     if with_search:
         blueprint.route('/search', methods=['GET'])(search)

--- a/arxiv/marxdown/routes.py
+++ b/arxiv/marxdown/routes.py
@@ -107,6 +107,7 @@ def get_blueprint(site_path: str, with_search: bool = True) -> Blueprint:
                           template_folder=site.get_templates_path(),
                           static_url_path=f'{site.get_site_name()}_static')
     blueprint.route('/')(from_sitemap)
+    blueprint.route('/<path:page_path>.html', endpoint="html")(from_sitemap)
     blueprint.route('/<path:page_path>')(from_sitemap)
     if with_search:
         blueprint.route('/search', methods=['GET'])(search)

--- a/arxiv/marxdown/tests/test_serve.py
+++ b/arxiv/marxdown/tests/test_serve.py
@@ -116,7 +116,7 @@ class TestServeSite(TestCase):
         client = app.test_client()
 
         with app.app_context():
-            response = client.get('/index.html')
+            response = client.get('/index.html', follow_redirects=True)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertIn(b'<title>This is the index', response.data)
             self.assertIn(b'<h1 id="this-is-the-index">This is the index</h1>',
@@ -124,7 +124,7 @@ class TestServeSite(TestCase):
             self.assertIn(b'<p>Here is <a href="foo">link</a>.</p>',
                           response.data)
 
-            response = client.get('/foo.html')
+            response = client.get('/foo.html', follow_redirects=True)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertIn(b'<title>Another foo page', response.data)
             self.assertIn(b'<h1 id="another-foo-page">Another foo page</h1>',
@@ -132,7 +132,7 @@ class TestServeSite(TestCase):
             self.assertIn(b'<p>See also <a href="baz">baz</a>.</p>',
                           response.data)
 
-            response = client.get('/baz.html')
+            response = client.get('/baz.html', follow_redirects=True)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertIn(b'<title>Baz Page', response.data)
             self.assertIn(
@@ -140,10 +140,10 @@ class TestServeSite(TestCase):
                 response.data
             )
 
-            response = client.get('/nope.html')
+            response = client.get('/nope.html', follow_redirects=True)
             self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-            response = client.get('/baz/deleted.html', follow_redirects=False)
+            response = client.get('/baz/deleted.html', follow_redirects=True)
             self.assertEqual(response.status_code,
                              status.HTTP_404_NOT_FOUND)
             self.assertIn(b'Not here', response.data)
@@ -151,51 +151,54 @@ class TestServeSite(TestCase):
             response = client.get('/baz/redirectme.html',
                                   follow_redirects=False)
             self.assertEqual(response.status_code,
-                             status.HTTP_301_MOVED_PERMANENTLY)
+                             status.HTTP_302_FOUND)
             self.assertEqual(response.headers['Location'],
-                             'http://localhost/foo')
+                             'http://localhost/baz/redirectme')
 
-        def test_serve_with_htm(self):
-            """Legacy URLs that end in .htm should be handled gracefully."""
-            app = factory.create_web_app()
-            client = app.test_client()
+    @mock.patch(f'{factory.__name__}.config', CONFIG)
+    def test_serve_with_htm(self):
+        """Legacy URLs that end in .htm should be handled gracefully."""
+        app = factory.create_web_app()
+        client = app.test_client()
 
-            with app.app_context():
-                response = client.get('/index.htm')
-                self.assertEqual(response.status_code, status.HTTP_200_OK)
-                self.assertIn(b'<title>This is the index', response.data)
-                self.assertIn(b'<h1 id="this-is-the-index">This is the index</h1>',
-                              response.data)
-                self.assertIn(b'<p>Here is <a href="foo">link</a>.</p>',
-                              response.data)
+        with app.app_context():
+            response = client.get('/index.htm', follow_redirects=True)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertIn(b'<title>This is the index', response.data)
+            self.assertIn(b'<h1 id="this-is-the-index">This is the index</h1>',
+                          response.data)
+            self.assertIn(b'<p>Here is <a href="foo">link</a>.</p>',
+                          response.data)
 
-                response = client.get('/foo.htm')
-                self.assertEqual(response.status_code, status.HTTP_200_OK)
-                self.assertIn(b'<title>Another foo page', response.data)
-                self.assertIn(b'<h1 id="another-foo-page">Another foo page</h1>',
-                              response.data)
-                self.assertIn(b'<p>See also <a href="baz">baz</a>.</p>',
-                              response.data)
+            response = client.get('/foo.htm', follow_redirects=True)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertIn(b'<title>Another foo page', response.data)
+            self.assertIn(b'<h1 id="another-foo-page">Another foo page</h1>',
+                          response.data)
+            self.assertIn(b'<p>See also <a href="baz">baz</a>.</p>',
+                          response.data)
 
-                response = client.get('/baz.htm')
-                self.assertEqual(response.status_code, status.HTTP_200_OK)
-                self.assertIn(b'<title>Baz Page', response.data)
-                self.assertIn(
-                    b'<h1 id="the-baz-index-page">The baz index page</h1>',
-                    response.data
-                )
+            response = client.get('/baz.htm', follow_redirects=True)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertIn(b'<title>Baz Page', response.data)
+            self.assertIn(
+                b'<h1 id="the-baz-index-page">The baz index page</h1>',
+                response.data
+            )
 
-                response = client.get('/nope.htm')
-                self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+            response = client.get('/nope.htm', follow_redirects=True)
+            self.assertEqual(response.status_code,
+                             status.HTTP_404_NOT_FOUND)
 
-                response = client.get('/baz/deleted.htm', follow_redirects=False)
-                self.assertEqual(response.status_code,
-                                 status.HTTP_404_NOT_FOUND)
-                self.assertIn(b'Not here', response.data)
+            response = client.get('/baz/deleted.htm',
+                                  follow_redirects=True)
+            self.assertEqual(response.status_code,
+                             status.HTTP_404_NOT_FOUND)
+            self.assertIn(b'Not here', response.data)
 
-                response = client.get('/baz/redirectme.htm',
-                                      follow_redirects=False)
-                self.assertEqual(response.status_code,
-                                 status.HTTP_301_MOVED_PERMANENTLY)
-                self.assertEqual(response.headers['Location'],
-                                 'http://localhost/foo')
+            response = client.get('/baz/redirectme.htm',
+                                  follow_redirects=False)
+            self.assertEqual(response.status_code,
+                             status.HTTP_302_FOUND)
+            self.assertEqual(response.headers['Location'],
+                             'http://localhost/baz/redirectme')


### PR DESCRIPTION
URLs that end in ``.html`` are handled. E.g. ``/some/legacy/path.html`` is treated just like ``/some/legacy/path``.